### PR TITLE
enhance spec detection

### DIFF
--- a/Gladius/Gladius.lua
+++ b/Gladius/Gladius.lua
@@ -690,7 +690,7 @@ function Gladius:UNIT_SPELLCAST_START(event, unit)
 		end
 
 		-- Spec detection
-		self:DetectSpec(unit, self.specSpells[spell])
+		self:DetectSpec(unit, self.specSpells[spell] or self.specBuffs[spell])
 
 		-- Resurrection alert
 		if(RESURRECTION_SPELLS[spell] and db.resAnnounce) then
@@ -1119,7 +1119,7 @@ function Gladius:UNIT_SPELLCAST_SUCCEEDED(event, unit, spell, rank)
 		if ( unit == "player" ) then unit = "arena1" end
 
 		-- Spec detection for instant cast spells
-		self:DetectSpec(unit, self.specSpells[spell])
+		self:DetectSpec(unit, self.specSpells[spell] or self.specBuffs[spell])
 
 		-- Cooldown detection
       local unitClass = select(2, UnitClass(unit))


### PR DESCRIPTION
Addon does following steps after spell casted:

1. Determine spec using specSpells (add cooldown icons if succeeded)
2. Start cooldown (if cooldown icon present)
3. UNIT_AURA fired - spec are getting determine using specBuffs list (add cooldown icons if succeeded)

But if spell is in specBuffs but not in specSpells, the cooldown will not be started.

fixes #13 

P.s.: the right way to fix it is to duplicate certain spells from specBuffs in specSpells. But I decided to go more "hackish" and easier way,
