### PR TITLE
Dont hide unit button after unit gets destroyed status

### DIFF
--- a/Gladius/Gladius.lua
+++ b/Gladius/Gladius.lua
@@ -1647,7 +1647,7 @@ function Gladius:ARENA_OPPONENT_UPDATE(event, unit, type)
 		elseif(type == "unseen") then
 			Gladius.buttons[unit]:SetAlpha(0.25)
 		elseif(type == "destroyed") then
-			Gladius.buttons[unit]:SetAlpha(0)
+			Gladius.buttons[unit]:SetAlpha(0.25)
 		end
 	end
 end


### PR DESCRIPTION
ARENA_OPPONENT_UPDATE is fired with "destroyed" reason after unit uses stealth ability.

fixes #15 